### PR TITLE
Correct block face issues (dispensers, pumpkins)

### DIFF
--- a/src/minecraft/terrain/builder.d
+++ b/src/minecraft/terrain/builder.d
@@ -821,6 +821,18 @@ template BlockDispatcher(alias T)
 		makeXYZ(dec, x, y, z, set);
 	}
 
+	void dispenser(int x, int y, int z) {
+		auto dec = &tile[23];
+		auto decFront = &dispenserFrontTile;
+		int set = data.getSolidSet(x, y, z);
+		auto d = data.getDataUnsafe(x, y, z);
+
+		auto faceNormal = [sideNormal.ZN, sideNormal.ZP,
+				   sideNormal.XN, sideNormal.XP][d-2];
+
+		makeFacedBlock(dec, decFront, x, y, z, faceNormal, set);
+	}
+
 	void wool(int x, int y, int z) {
 		auto dec = &woolTile[data.getDataUnsafe(x, y, z)];
 		solidDec(dec, x, y, z);
@@ -1053,18 +1065,10 @@ template BlockDispatcher(alias T)
 		int set = data.getSolidSet(x, y, z);
 		auto d = data.getDataUnsafe(x, y, z);
 
-		if (set & sideMask.ZN)
-			makeXZ((d == 2) ? decFront : dec, x, y, z, sideNormal.ZN);
-		if (set & sideMask.ZP)
-			makeXZ((d == 3) ? decFront : dec, x, y, z, sideNormal.ZP);
-		if (set & sideMask.XN)
-			makeXZ((d == 4) ? decFront : dec, x, y, z, sideNormal.XN);
-		if (set & sideMask.XP)
-			makeXZ((d == 5) ? decFront : dec, x, y, z, sideNormal.XP);
-		if (set & sideMask.YN)
-			makeY(dec, x, y, z, sideNormal.YN);
-		if (set & sideMask.YP)
-			makeY(dec, x, y, z, sideNormal.YP);
+		auto faceNormal = [sideNormal.ZN, sideNormal.ZP,
+				   sideNormal.XN, sideNormal.XP][d-2];
+
+		makeFacedBlock(dec, decFront, x, y, z, faceNormal, set);
 	}
 
 	void wallsign(int x, int y, int z) {
@@ -1107,6 +1111,30 @@ template BlockDispatcher(alias T)
 		solid(80, x, y, z);
 	}
 
+	void pumpkin(int x, int y, int z) {
+		auto dec = &tile[86];
+		auto decFront = &pumpkinFrontTile;
+		int set = data.getSolidSet(x, y, z);
+		auto d = data.getDataUnsafe(x, y, z);
+
+		auto faceNormal = [sideNormal.ZN, sideNormal.XP,
+				   sideNormal.ZP, sideNormal.XN][d];
+
+		makeFacedBlock(dec, decFront, x, y, z, faceNormal, set);
+	}
+
+	void jack_o_lantern(int x, int y, int z) {
+		auto dec = &tile[91];
+		auto decFront = &jackolanternFrontTile;
+		int set = data.getSolidSet(x, y, z);
+		auto d = data.getDataUnsafe(x, y, z);
+
+		auto faceNormal = [sideNormal.ZN, sideNormal.XP,
+				   sideNormal.ZP, sideNormal.XN][d];
+
+		makeFacedBlock(dec, decFront, x, y, z, faceNormal, set);
+	}
+
 	void b(uint x, uint y, uint z) {
 		static int count = 0;
 		ubyte type = data.get(x, y, z);
@@ -1127,6 +1155,9 @@ template BlockDispatcher(alias T)
 				break;
 			case 20:
 				glass(x, y, z);
+				break;
+			case 23:
+				dispenser(x, y, z);
 				break;
 			case 35:
 				wool(x, y, z);
@@ -1170,6 +1201,12 @@ template BlockDispatcher(alias T)
 				break;
 			case 78:
 				snow(x, y, z);
+				break;
+			case 86:
+				pumpkin(x, y, z);
+				break;
+			case 91:
+				jack_o_lantern(x, y, z);
 				break;
 			default:
 				if (tile[type].filled)

--- a/src/minecraft/terrain/data.d
+++ b/src/minecraft/terrain/data.d
@@ -59,7 +59,7 @@ BlockDescriptor tile[256] = [
 	{ false, Stuff,     {  1,  3 }, {  1,  3 }, "glass" },
 	{  true, Block,     {  0, 10 }, {  0, 10 }, "lapis lazuli ore" },
 	{  true, Block,     {  0,  9 }, {  0,  9 }, "lapis lazuli block" },
-	{  true, DataBlock, { 14,  2 }, { 14,  3 }, "dispenser" },
+	{  true, DataBlock, { 13,  2 }, { 14,  3 }, "dispenser" },
 	{  true, Block,     {  0, 12 }, {  0, 11 }, "sand Stone" },            // 24
 	{  true, Block,     { 10,  4 }, { 10,  4 }, "note block" },
 	{ false, Stuff,     {  0,  4 }, {  0,  4 }, "bed" },
@@ -122,12 +122,12 @@ BlockDescriptor tile[256] = [
 	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "sugar cane" },
 	{  true, Block,     { 10,  4 }, { 11,  4 }, "jukebox" },
 	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "fence" },
-	{  true, DataBlock, {  7,  7 }, {  6,  6 }, "pumpkin" },
+	{  true, DataBlock, {  6,  7 }, {  6,  6 }, "pumpkin" },
 	{  true, Block,     {  7,  6 }, {  7,  6 }, "netherrack" },
 	{  true, Block,     {  8,  6 }, {  8,  6 }, "soul sand" },             // 88
 	{  true, Block,     {  9,  6 }, {  9,  6 }, "glowstone block" },
 	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "portal" },
-	{  true, DataBlock, {  8,  7 }, {  6,  6 }, "jack-o-lantern" },
+	{  true, DataBlock, {  6,  7 }, {  6,  6 }, "jack-o-lantern" },
 	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "cake block" },
 	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "redstone repeater off" },
 	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "redstone repeater on" },
@@ -188,3 +188,12 @@ BlockDescriptor farmlandTile[2] = [
 
 BlockDescriptor furnaceFrontTile =
 	{  true, DataBlock, { 12,  2 }, { 14,  3 }, "furnace" };
+
+BlockDescriptor dispenserFrontTile =
+	{  true, DataBlock, { 14,  2 }, { 14,  3 }, "dispenser" };
+
+BlockDescriptor pumpkinFrontTile =
+	{  true, DataBlock, {  7,  7 }, {  6,  6 }, "pumpkin" };
+
+BlockDescriptor jackolanternFrontTile =
+	{  true, DataBlock, {  8,  7 }, {  6,  6 }, "jack-o-lantern" };


### PR DESCRIPTION
I've implemented a `makeFacedBlock` as you suggested, rewrote `furnace` to use it and added handlers for dispensers, pumpkins and jack-o-lanterns. One thing that bothers me a bit is the almost identical code in furnace/dispenser and pumpkin/jack_o_lanterns. I could combine these and make them accept both type and decFront, but I'm not sure that makes it much better.
