### PR TITLE
mc: Render pressure plates.

### DIFF
--- a/src/minecraft/terrain/builder.d
+++ b/src/minecraft/terrain/builder.d
@@ -1158,6 +1158,26 @@ template BlockDispatcher(alias T)
 		emitQuadYP(x1, x2, y2, z1, z2, tex, sideNormal.YP);
 	}
 
+	void pressure_plate(ubyte type, int x, int y, int z) {
+		auto dec = &tile[type];
+		ubyte tex = calcTextureXZ(dec);
+
+		const shift = VERTEX_SIZE_BIT_SHIFT;
+		x <<= shift;
+		y <<= shift;
+		z <<= shift;
+
+		int x1 = x+1, x2 = x+15;
+		int z1 = z+1, z2 = z+15;
+		int y1 = y, y2 = y+1;
+
+		emitQuadXZN(x1, x1, y1, y2, z1, z2, tex, sideNormal.XN);
+		emitQuadXZP(x2, x2, y1, y2, z1, z2, tex, sideNormal.XP);
+		emitQuadXZN(x1, x2, y1, y2, z1, z1, tex, sideNormal.ZN);
+		emitQuadXZP(x1, x2, y1, y2, z2, z2, tex, sideNormal.ZP);
+		emitQuadYP(x1, x2, y2, z1, z2, tex, sideNormal.YP);
+	}
+
 	void snow(int x, int y, int z) {
 		// Make snow into full block for now
 		solid(80, x, y, z);
@@ -1288,6 +1308,10 @@ template BlockDispatcher(alias T)
 				break;
 			case 68:
 				wallsign(x, y, z);
+				break;
+			case 70:
+			case 72:
+				pressure_plate(type, x, y, z);
 				break;
 			case 78:
 				snow(x, y, z);

--- a/src/minecraft/terrain/data.d
+++ b/src/minecraft/terrain/data.d
@@ -106,9 +106,9 @@ BlockDescriptor tile[256] = [
 	{ false, Stuff,     {  0,  1 }, {  0,  1 }, "clobblestone stairs" },
 	{ false, Stuff,     {  4,  0 }, {  4,  0 }, "wall sign" },
 	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "lever" },
-	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "stone pressure plate" },
+	{ false, Stuff,     {  1,  0 }, {  1,  0 }, "stone pressure plate" },
 	{ false, Stuff,     {  2,  5 }, {  2,  6 }, "iron door" },
-	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "wooden pressure plate" }, // 72
+	{ false, Stuff,     {  4,  0 }, {  4,  0 }, "wooden pressure plate" }, // 72
 	{  true, Block,     {  3,  3 }, {  3,  3 }, "redostone ore" },
 	{  true, Block,     {  3,  3 }, {  3,  3 }, "glowing rstone ore" },
 	{ false, Stuff,     {  0,  0 }, {  0,  0 }, "redstone torch off" },


### PR DESCRIPTION
Pressure plates don't show a difference between pressed and not pressed
yet.
## 

In normal state, plates are only 1 pixel heigh, to show a pressed state they would need to be totally flat. I think it wouldn't look good and probably could cause some glitches when 2 faces overlay each other.
