### PR TITLE
mc: Render sapling types correctly.

### DIFF
--- a/src/minecraft/terrain/builder.d
+++ b/src/minecraft/terrain/builder.d
@@ -838,6 +838,23 @@ template BlockDispatcher(alias T)
 		solidDec(dec, x, y, z);
 	}
 
+	void sapling(int x, int y, int z) {
+		auto d = data.getDataUnsafe(x, y, z);
+		auto dec = &saplingTile[d & 3];
+		auto tex = calcTextureXZ(dec);
+
+		const shift = VERTEX_SIZE_BIT_SHIFT;
+		x <<= shift;
+		y <<= shift;
+		z <<= shift;
+
+		int x1 = x, x2 = x+16;
+		int y1 = y, y2 = y+16;
+		int z1 = z, z2 = z+16;
+
+		emitDiagonalQuads(x1, x2, y1, y2, z1, z2, tex);
+	}
+
 	void plants(ubyte type, int x, int y, int z) {
 		auto desc = &tile[type];
 		auto tex = calcTextureXZ(desc);
@@ -1245,6 +1262,8 @@ template BlockDispatcher(alias T)
 				wool(x, y, z);
 				break;
 			case 6:
+				sapling(x, y, z);
+				break;
 			case 37:
 			case 38:
 			case 39:

--- a/src/minecraft/terrain/data.d
+++ b/src/minecraft/terrain/data.d
@@ -160,6 +160,13 @@ BlockDescriptor woodTile[3] = [
 	{  true, Block,     {  5,  7 }, {  5,  1 }, "birch" }
 ];
 
+BlockDescriptor saplingTile[4] = [
+	{ false, Stuff,     { 15,  0 }, { 15,  0 }, "normal" },
+	{ false, Stuff,     { 15,  3 }, { 15,  3 }, "spruce" },
+	{ false, Stuff,     { 15,  4 }, { 15,  4 }, "birch" },
+	{ false, Stuff,     { 15,  0 }, { 15,  0 }, "normal" },
+];
+
 BlockDescriptor craftingTableAltTile =
 	{  true, DataBlock, { 12,  3 }, { 11,  2 }, "crafting table" };
 


### PR DESCRIPTION
The sapling type was ignored, this fix this. In case your wondering about four types, 0x3 is used too (according to minecraftwiki.net and my observations). It uses the default texture.
